### PR TITLE
fix command palette is showing when printing

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -64,7 +64,11 @@ body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
 
 @media print {
   .no-print {
-    display: none;
+    display: none !important;
+  }
+
+  .cdk-overlay-backdrop.cdk-overlay-backdrop-showing {
+    opacity: 0;
   }
 }
 


### PR DESCRIPTION
fix command palette is showing when printing

screenshot:
![image](https://github.com/brunooprotti/my-portfolio/assets/20303892/d51bdb5a-1654-40ed-9f69-81823297f512)
